### PR TITLE
Suggestion for Internationalisation Panel

### DIFF
--- a/panels.md
+++ b/panels.md
@@ -16,3 +16,12 @@ This is an example that people can use as a template for submitting their own pa
 #### Panelists
 - Panelist Name <[email@example.org](mailto:email@example.org)>
 - Panelist Name <[email@example.org](mailto:email@example.org)>
+
+## Internationalisation Panel
+To ensure internationalisation is taken into consideration during the Solid design. 
+
+### Communication channels
+- [public-solid@w3.org](https://lists.w3.org/Archives/Public/public-solid/)
+
+#### Panelists
+- 


### PR DESCRIPTION
@HelloFillip  and @elf-pavlik currently have a team on internationalisation https://github.com/orgs/solid/teams  that could fit nicely as a panel so I've added them as reviewers. I would propose closing the internationalisation team if this panel unless there are any objections.