### PR TITLE
change TOC to Index

### DIFF
--- a/panels.md
+++ b/panels.md
@@ -18,7 +18,7 @@ This is an example that people can use as a template for submitting their own pa
 - Panelist Name <[email@example.org](mailto:email@example.org)>
 - Panelist Name <[email@example.org](mailto:email@example.org)>
 
-## Table of Contents
+## Index of Panels
 
 * [Accessibility Panel](#accessibility-panel)
 * [App Authorization Panel](#app-authorization)


### PR DESCRIPTION
TOC is in order of content that follows.  

Index is in alpha-numeric order of listed terms.